### PR TITLE
Validate and launch docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
     build: ./backend
     container_name: recipes_api
     env_file: .env
-    environment:
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Remove empty `environment:` from `api` service to fix Docker Compose validation error.

The `environment:` section was empty, which is invalid Docker Compose syntax and caused the `services.api.environment must be a mapping` error. The service already uses `env_file: .env`, making the `environment:` section redundant.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec704313-6f64-4ee4-9ee4-b426075ea0c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec704313-6f64-4ee4-9ee4-b426075ea0c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

