### PR TITLE
Fix express type mismatch in profile route

### DIFF
--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -1,9 +1,9 @@
 import { Router, Request, Response } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { pgPool } from '../db/pool.js';
-import multer from 'multer';
-import path from 'path';
-import fs from 'fs';
+import * as multer from 'multer';
+import * as path from 'path';
+import * as fs from 'fs';
 
 export const profileRouter = Router();
 
@@ -86,7 +86,7 @@ profileRouter.put('/', requireAuth, async (req: Request, res: Response) => {
 });
 
 // Upload profile picture
-profileRouter.post('/profile-picture', requireAuth, upload.single('profilePicture'), async (req: Request, res: Response) => {
+profileRouter.post('/profile-picture', requireAuth, upload.single('profilePicture'), async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No file uploaded' });


### PR DESCRIPTION
Remove explicit type annotations and fix import statements in `profile.ts` to resolve TypeScript compilation errors.

The primary issue was a `TS2769` error where explicit `Request` and `Response` types on a route handler conflicted with the types introduced by `multer` middleware. Removing these annotations allows TypeScript to correctly infer the types. Additionally, import statements were updated to use namespace imports (`* as`) to resolve ES module-related compilation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2cff1f2-b2b0-4a91-b920-b85216a7b02c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2cff1f2-b2b0-4a91-b920-b85216a7b02c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

